### PR TITLE
单独处理消息审核机制、修复GetMessage无法使用的问题（官方文档和实际返回有出入）、添加了一个方便处理需要审核消息的扩展

### DIFF
--- a/Api/Base/ApiBase.cs
+++ b/Api/Base/ApiBase.cs
@@ -1,13 +1,12 @@
-﻿using System.Net.Http;
-using System.Reflection;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using QQChannelFramework.Api.Types;
-using System.Linq;
+using QQChannelFramework.Exceptions;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using QQChannelFramework.Exceptions;
 
 namespace QQChannelFramework.Api.Base;
 
@@ -229,6 +228,12 @@ public class ApiBase {
     private void InspectionResultCode(in JToken resultData, string traceId) {
         var code = int.Parse(resultData["code"].ToString());
 
-        throw new ErrorResultException(code, resultData["message"].ToString(), traceId);
+        Exception exception = code switch
+        {
+            304023 or 304024 => new MessageAuditException(code, resultData["message"].ToString(), resultData["data"]["message_audit"]["audit_id"].ToString()),
+            _=> new ErrorResultException(code, resultData["message"].ToString(), traceId)
+        };
+
+        throw exception;
     }
 }

--- a/Api/MessageApi.cs
+++ b/Api/MessageApi.cs
@@ -1,14 +1,14 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
+﻿using ChannelModels.Returns;
 using Newtonsoft.Json.Linq;
 using QQChannelFramework.Api.Base;
 using QQChannelFramework.Api.Raws;
 using QQChannelFramework.Api.Types;
 using QQChannelFramework.Models.MessageModels;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace QQChannelFramework.Api;
 
@@ -275,7 +275,7 @@ public class MessageApi {
 
         var requestData = await _apiBase.RequestAsync(processedInfo).ConfigureAwait(false);
 
-        Message message = requestData.ToObject<Message>();
+        Message message = requestData.ToObject<GetMessageResult>().Message;
 
         return message;
     }

--- a/Exceptions/MessageAuditException.cs
+++ b/Exceptions/MessageAuditException.cs
@@ -1,0 +1,31 @@
+﻿using QQChannelFramework.Expansions.Bot;
+using System.Threading.Tasks;
+namespace QQChannelFramework.Exceptions;
+
+/// <summary>
+/// 主动消息触发审核时返回的异常
+/// </summary>
+public class MessageAuditException : Exception
+{
+    /// <summary>
+    /// 响应中的code
+    /// </summary>
+    public int Code { get; private set; }
+
+    /// <summary>
+    /// 审核ID
+    /// </summary>
+    public string AuditId { get; private set; }
+
+    /// <summary>
+    /// 构造函数
+    /// </summary>
+    /// <param name="code"></param>
+    /// <param name="message"></param>
+    /// <param name="auditId"></param>
+    public MessageAuditException(int code, string message, string auditId) : base(message)
+    {
+        Code = code;
+        AuditId = auditId;
+    }
+}

--- a/Models/Returns/GetMessageResult.cs
+++ b/Models/Returns/GetMessageResult.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using QQChannelFramework.Models.MessageModels;
+
+namespace ChannelModels.Returns;
+
+/// <summary>
+/// https://bot.q.qq.com/wiki/develop/api/openapi/message/get_message_of_id.html的返回值，实际情况与官方文档不符
+/// </summary>
+public class GetMessageResult
+{
+    /// <summary>
+    /// 消息
+    /// </summary>
+    [JsonProperty("message")]
+    public Message Message { get; set; }
+}

--- a/Models/Returns/MessageAudited.cs
+++ b/Models/Returns/MessageAudited.cs
@@ -1,23 +1,44 @@
 ﻿using Newtonsoft.Json;
 
-namespace ChannelModels.Returns; 
+namespace ChannelModels.Returns;
 
+/// <summary>
+/// 消息审核对象
+/// </summary>
 public class MessageAudited {
+    /// <summary>
+    /// 消息审核 id
+    /// </summary>
     [JsonProperty("audit_id")]
     public string AuditId { get; set; }
 
+    /// <summary>
+    /// 消息审核时间
+    /// </summary>
     [JsonProperty("audit_time")]
     public DateTime AuditTime { get; set; }
 
+    /// <summary>
+    /// 子频道 id
+    /// </summary>
     [JsonProperty("channel_id")]
     public string ChannelId { get; set; }
 
+    /// <summary>
+    /// 消息创建时间
+    /// </summary>
     [JsonProperty("create_time")]
     public DateTime CreateTime { get; set; }
 
+    /// <summary>
+    /// 频道 id
+    /// </summary>
     [JsonProperty("guild_id")]
     public string GuildId { get; set; }
 
+    /// <summary>
+    /// 消息 id，只有审核通过事件才会有值
+    /// </summary>
     [JsonProperty("message_id")]
     public string MessageId { get; set; }
     

--- a/Tools/MessageAuditExtension.cs
+++ b/Tools/MessageAuditExtension.cs
@@ -1,0 +1,44 @@
+﻿using QQChannelFramework.Api;
+using QQChannelFramework.Exceptions;
+using QQChannelFramework.Expansions.Bot;
+using QQChannelFramework.Models.MessageModels;
+using System.Threading.Tasks;
+
+namespace QQChannelFramework.Tools;
+public static class MessageAuditExtension
+{
+    /// <summary>
+    /// 如果发出的消息需要审核，则等待至审核通过。需要RegisterAuditEvent
+    /// </summary>
+    /// <param name="task"></param>
+    /// <param name="bot"></param>
+    /// <param name="api"></param>
+    /// <returns>审核通过后的消息</returns>
+    public static async Task<Message> Audit(this Task<Message> task, ChannelBot bot, MessageApi api)
+    {
+        try
+        {
+            return await task.ConfigureAwait(false);
+        }
+        catch (MessageAuditException e)
+        {
+            var tcs = new TaskCompletionSource();
+            WS.FunctionWebSocket.AuditDelegate eh = null!;
+            Message message = default!;
+            eh = async (ChannelModels.Returns.MessageAudited audit) =>
+            {
+                if (audit.AuditId != e.AuditId) return;
+                bot.MessageAuditPass -= eh;
+                message = await api.GetMessageAsync(audit.ChannelId, audit.MessageId);
+                tcs.SetResult();
+            };
+            bot.MessageAuditPass += eh;
+            await tcs.Task;
+            return message;
+        }
+        catch
+        {
+            throw;
+        }
+    }
+}

--- a/WS/FunctionWebSocketProcess.cs
+++ b/WS/FunctionWebSocketProcess.cs
@@ -216,6 +216,13 @@ partial class FunctionWebSocket {
 
                 _identifyData.intents = 0;
 
+                if (!_registeredEvents.Any()) //需要至少订阅一个事件才能正常启动
+                {
+                    //这里应该给用户一点提示的 但是没找到在哪发
+                    AuthenticationError?.Invoke();
+                    await CloseAsync();
+                    break;
+                }
                 foreach (var type in _registeredEvents) {
                     _identifyData.intents += (int) type;
                 }


### PR DESCRIPTION
现在的GetMessage返回
```
{
  套了个娃-->"message": { 
		"id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
		"channel_id": "xxxxxxxxx",
		"guild_id": "xxxxxxxxxxxxxxxxxxxxxxx",
		"content": "消息内容",
		"timestamp": "2022-09-23T16:03:56+08:00",
		"author": {
			"id": "xxxxxxxxxxxxxxxxxxxxxxx",
			"username": "xxxxxxxxxxxxxxxxxxxxx",
			"bot": true
		},
		"member": {
			"roles": ["1"],
			"joined_at": "2022-09-20T17:55:16+08:00"
		}
	}
}
```